### PR TITLE
[Package Monitor] Bumps vim from 9.1.0318 to 9.1.1404

### DIFF
--- a/linux/applications/editors/vim/.hab-plan-config.toml
+++ b/linux/applications/editors/vim/.hab-plan-config.toml
@@ -1,0 +1,7 @@
+[rules]
+missing-license = { level = "off", source-shasum = "96ab430f7e0902361cf67dd8390b7ea54672df580328067720d874ecdbc3f995" }
+license-not-found = { level = "off", source-shasum = "96ab430f7e0902361cf67dd8390b7ea54672df580328067720d874ecdbc3f995" }
+# We ignore scripts in the share folder
+host-script-interpreter = {ignored_files = ["share/*"]}
+missing-script-interpreter-dependency = {level = "off", ignored_files = ["share/*"]}
+unused-runpath-entry = {ignored_files = ["bin/*"]}

--- a/linux/applications/editors/vim/plan.sh
+++ b/linux/applications/editors/vim/plan.sh
@@ -1,0 +1,61 @@
+pkg_name="vim"
+pkg_origin="core"
+pkg_version="9.1.1404"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="\
+Vim is a highly configurable text editor built to make creating and changing \
+any kind of text very efficient. It is included as "vi" with most UNIX \
+systems and with Apple OS X.\
+"
+pkg_upstream_url="http://www.vim.org/"
+pkg_license=('Vim' 'BSD-2-Clause' 'LGPL-2.1-or-later' 'MIT' 'PSF-2.0' 'X11')
+pkg_source="http://github.com/${pkg_name}/${pkg_name}/archive/v${pkg_version}.tar.gz"
+pkg_shasum="96ab430f7e0902361cf67dd8390b7ea54672df580328067720d874ecdbc3f995"
+pkg_deps=(
+	core/acl
+	core/glibc
+	core/ncurses
+	core/gawk
+)
+pkg_build_deps=(
+	core/autoconf
+	core/gcc
+	core/shadow
+)
+pkg_bin_dirs=(bin)
+
+do_prepare() {
+	pushd src >/dev/null
+	autoconf
+	popd >/dev/null
+
+	export CFLAGS="${CFLAGS} -O2"
+	build_line "Setting CFLAGS=${CFLAGS}"
+}
+
+do_build() {
+	./configure \
+		--prefix="${pkg_prefix}" \
+		--with-compiledby="Habitat, vim release ${pkg_version}" \
+		--with-features=huge \
+		--enable-acl \
+		--with-x=no \
+		--disable-gui \
+		--enable-multibyte
+	make
+}
+
+do_check() {
+	chown -R hab .
+	su hab -c "PATH=$PATH LANG=en_US.UTF-8 make -j1 test &>vim-test.log"
+}
+
+do_install() {
+	make install
+
+	# Add a `vi` which symlinks to `vim`
+	ln -sv vim "${pkg_prefix}/bin/vi"
+
+	# Install license file
+	install -Dm644 runtime/doc/uganda.txt "${pkg_prefix}/share/licenses/license.txt"
+}


### PR DESCRIPTION
## Updates
- Bumps vim from 9.1.0318 to 9.1.1404.
