### PR TITLE
[binutils] upgraded to v2.44

### DIFF
--- a/linux/bootstrap/stage1/binutils/x86_64-linux/.hab-plan-config.toml
+++ b/linux/bootstrap/stage1/binutils/x86_64-linux/.hab-plan-config.toml
@@ -1,9 +1,10 @@
 [rules]
-license-not-found = {level = "off", source-shasum = "da24a84fef220102dd24042df06fdea851c2614a5377f86effa28f33b7b16148"}
-missing-license = {level = "off", source-shasum = "da24a84fef220102dd24042df06fdea851c2614a5377f86effa28f33b7b16148"}
+license-not-found = {level = "off", source-shasum = "f66390a661faa117d00fab2e79cf2dc9d097b42cc296bf3f8677d1e7b452dc3a"}
+missing-license = {level = "off", source-shasum = "f66390a661faa117d00fab2e79cf2dc9d097b42cc296bf3f8677d1e7b452dc3a"}
 unused-dependency = {ignored_packages = [
     "core/hab-ld-wrapper",
-    "core/bash-static"
+    "core/bash-static",
+    "core/gcc-libs-stage1"
 ]}
 # The core/gcc-libs-stage1 lib folder is added extraneously for a lot of binaries because it is linked --as-needed
 # for these binaries. Since core/gcc-libs-stage1 is in the deps, it gets added in.

--- a/linux/bootstrap/stage1/binutils/x86_64-linux/plan.sh
+++ b/linux/bootstrap/stage1/binutils/x86_64-linux/plan.sh
@@ -2,7 +2,7 @@ program="binutils"
 
 pkg_name="binutils-stage1"
 pkg_origin="core"
-pkg_version="2.39"
+pkg_version="2.44"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
 The GNU Binary Utilities, or binutils, are a set of programming tools for \
@@ -12,7 +12,7 @@ and assembly source code.\
 pkg_upstream_url="https://www.gnu.org/software/binutils/"
 pkg_license=('GPL-3.0-or-later')
 pkg_source="http://ftp.gnu.org/gnu/${program}/${program}-${pkg_version}.tar.bz2"
-pkg_shasum="da24a84fef220102dd24042df06fdea851c2614a5377f86effa28f33b7b16148"
+pkg_shasum="f66390a661faa117d00fab2e79cf2dc9d097b42cc296bf3f8677d1e7b452dc3a"
 pkg_dirname="${program}-${pkg_version}"
 pkg_bin_dirs=(
 	bin
@@ -57,7 +57,7 @@ do_prepare() {
 
 	# Use symlinks instead of hard links to save space (otherwise `strip(1)`
 	# needs to process each hard link seperately)
-	for f in binutils/Makefile.in gas/Makefile.in ld/Makefile.in gold/Makefile.in; do
+	for f in binutils/Makefile.in gas/Makefile.in ld/Makefile.in; do
 		sed -i "$f" -e 's|ln |ln -s |'
 	done
 }
@@ -65,7 +65,6 @@ do_prepare() {
 do_build() {
 	./configure \
 		--prefix=$pkg_prefix \
-		--enable-gold=yes \
 		--enable-gprofng=no \
 		--enable-ld=default \
 		--enable-shared \

--- a/linux/development/tools/misc/binutils/.hab-plan-config.toml
+++ b/linux/development/tools/misc/binutils/.hab-plan-config.toml
@@ -1,8 +1,9 @@
 [rules]
-license-not-found = {level = "off", source-shasum = "da24a84fef220102dd24042df06fdea851c2614a5377f86effa28f33b7b16148"}
-missing-license = {level = "off", source-shasum = "da24a84fef220102dd24042df06fdea851c2614a5377f86effa28f33b7b16148"}
+license-not-found = {level = "off", source-shasum = "f66390a661faa117d00fab2e79cf2dc9d097b42cc296bf3f8677d1e7b452dc3a"}
+missing-license = {level = "off", source-shasum = "f66390a661faa117d00fab2e79cf2dc9d097b42cc296bf3f8677d1e7b452dc3a"}
 unused-dependency = {ignored_packages = [
     "core/bash-static",
-    "core/hab-ld-wrapper"
+    "core/hab-ld-wrapper",
+    "core/gcc-libs"
 ]}
 unused-runpath-entry = {level = "off"}

--- a/linux/development/tools/misc/binutils/plan.sh
+++ b/linux/development/tools/misc/binutils/plan.sh
@@ -2,7 +2,7 @@ program="binutils"
 
 pkg_name="binutils"
 pkg_origin="core"
-pkg_version="2.39"
+pkg_version="2.44"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
 The GNU Binary Utilities, or binutils, are a set of programming tools for \
@@ -12,7 +12,7 @@ and assembly source code.\
 pkg_upstream_url="https://www.gnu.org/software/binutils/"
 pkg_license=('GPL-3.0-or-later')
 pkg_source="http://ftp.gnu.org/gnu/${program}/${program}-${pkg_version}.tar.bz2"
-pkg_shasum="da24a84fef220102dd24042df06fdea851c2614a5377f86effa28f33b7b16148"
+pkg_shasum="f66390a661faa117d00fab2e79cf2dc9d097b42cc296bf3f8677d1e7b452dc3a"
 pkg_dirname="${program}-${pkg_version}"
 pkg_bin_dirs=(
 	bin
@@ -51,10 +51,10 @@ do_prepare() {
 		sed -i "$f" -e 's|-lfl|-l:libfl.a|'
 	done
 
-	sed -i /hab/cache/src/binutils-2.39/ld/configure -e 's|-lfl|-l:libfl.a|'
+	sed -i /hab/cache/src/binutils-${pkg_version}/ld/configure -e 's|-lfl|-l:libfl.a|'
 	# Use symlinks instead of hard links to save space (otherwise `strip(1)`
 	# needs to process each hard link seperately)
-	for f in binutils/Makefile.in gas/Makefile.in ld/Makefile.in gold/Makefile.in; do
+	for f in binutils/Makefile.in gas/Makefile.in ld/Makefile.in; do
 		sed -i "$f" -e 's|ln |ln -s |'
 	done
 }
@@ -62,7 +62,6 @@ do_prepare() {
 do_build() {
 	./configure \
 		--prefix=$pkg_prefix \
-		--enable-gold \
 		--enable-gprofng=no \
 		--enable-ld=default \
 		--enable-shared \
@@ -72,6 +71,7 @@ do_build() {
 		--enable-threads \
 		--enable-new-dtags \
 		--enable-64-bit-bfd \
+		--with-system-zlib \
 		--with-system-zlib
 
 	make tooldir="${pkg_prefix}" V=1
@@ -89,7 +89,6 @@ do_strip() {
 do_install() {
 	make tooldir="${pkg_prefix}" install
 	wrap_binary "ld.bfd"
-	wrap_binary "ld.gold"
 	# Remove unnecessary binaries
 	rm -v "${pkg_prefix:?}"/lib/lib{bfd,ctf,ctf-nobfd,opcodes}.{a,la}
 }


### PR DESCRIPTION
upgraded to v2.44 and to mitigate dynamic linking error with libbfd-2.39, core/binutils-stage1 is also upgraded as it is dependency for binutils

Signed-off-by: Nimit [nimit.jyotiana@hotmail.com](mailto:nimit.jyotiana@hotmail.com)