### PR TITLE
Fixes `core/rust` 1.91 package with linker issue.

### DIFF
--- a/linux/development/compilers/rust/glibc/x86_64-linux/.hab-plan-config.toml
+++ b/linux/development/compilers/rust/glibc/x86_64-linux/.hab-plan-config.toml
@@ -12,5 +12,5 @@ host-elf-interpreter = {level = "off"}
 # 3. core/tzdata - Needed for the proper operation of the GNU C Library (glibc).
 # 4. core/iana-etc - Also required for the functioning of glibc.
 unused-dependency = {ignored_packages = [
-    "core/{cacerts,binutils,tzdata,iana-etc}"
+    "core/{cacerts,binutils,tzdata,iana-etc,hab-ld-wrapper}"
 ]}

--- a/linux/development/compilers/rust/glibc/x86_64-linux/ld-wrapper.sh
+++ b/linux/development/compilers/rust/glibc/x86_64-linux/ld-wrapper.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+HAB_DEBUG=${HAB_DEBUG:-${HAB_LD_DEBUG:-0}} \
+HAB_LD_RUN_PATH=${HAB_LD_RUN_PATH:-${LD_RUN_PATH:-""}} \
+@wrapper@ @program@ "$@"

--- a/linux/development/compilers/rust/glibc/x86_64-linux/plan.sh
+++ b/linux/development/compilers/rust/glibc/x86_64-linux/plan.sh
@@ -21,6 +21,7 @@ pkg_deps=(
 	core/iana-etc
 	core/tzdata
 	core/zlib
+	core/hab-ld-wrapper
 )
 pkg_build_deps=(
 	core/build-tools-patchelf
@@ -147,8 +148,48 @@ do_install() {
 	# RUSTFLAGS to ensure the library's detection during the linking process.
 	wrap_rustc_binary
 
+	# The whole `lld` default Saga -
+	# TLDR; Since 1.90.0 `rust` enabled the `lld` by default that doesn't work with our
+	# non-standard paths and custom runtime `linker`. We just continue to use the *old*
+	# `ld.bfd` linker from `core/binutils`
+	#
+	# With the introduction of the `lld` linker, during the compilation of dependencies -
+	# running the `build-script-build` binaries fail to run causing compilation failure.
+	# This is because the binaries are dynamically linked even though we are trying to build
+	# statically linked binaries for the *target* (`x86_64-unknown-linux-musl` in our case).
+	#
+	# We can disable the `lld` default linker using `RUSTFLAGS` - but they are not honoured when
+	# `--target` is set as we do. In short we cannot disable the `lld` linker for the
+	# `build-script-build` compilation. With `lld` linker the `rpath` entries are not added in
+	# the generated binaries and hence they cannot be run.
+	#
+	# If we use our standard technique of wrapping with the wrapper calling original binary
+	# named `ld.lld.real`, this fails because `rustc`s `ld-wrapper` script expects the *called*
+	# binary name to be `ld.lld`. This leaves us with only choice of *wrapping* the *old*
+	# `ld.bfd.real` binary from the `core/binutils` package.
+	wrap_lld_linker "$pkg_prefix"/lib/rustlib/x86_64-unknown-linux-gnu/bin/gcc-ld/ld.lld \
+		"$(pkg_path_for binutils)"/bin/ld.bfd.real
+
 	# Delete the uninstaller script as it is not required
 	rm "${pkg_prefix}"/lib/rustlib/uninstall.sh
+}
+
+wrap_lld_linker() {
+	local wrapper_binary
+	local actual_binary
+
+	actual_binary="$2"
+	wrapper_binary="$1"
+
+	local hab_ld_wrapper
+	hab_ld_wrapper="$(pkg_path_for hab-ld-wrapper)"
+
+	sed "$PLAN_CONTEXT/ld-wrapper.sh" \
+		-e "s^@wrapper@^${hab_ld_wrapper}/bin/hab-ld-wrapper^g" \
+		-e "s^@program@^${actual_binary}^g" \
+		>"$wrapper_binary"
+
+	chmod 755 "$wrapper_binary"
 }
 
 wrap_rustc_binary() {


### PR DESCRIPTION
For the `build-script-build` binaries to be able to run during the compilation process, we need to disable the `lld` as it misses creating required `DT_RPATH` entries. Thus we replace the *actual* `ld.lld` linker with `hab-ld-wrapper.sh` wrapped `ld.bfd` linker from `core/binutils`.