### PR TITLE
bumping 7zip from 26.00 to 26.01

### DIFF
--- a/windows/tools/archivers/7zip/plan.ps1
+++ b/windows/tools/archivers/7zip/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="7zip"
 $pkg_origin="core"
-$pkg_version="26.00"
+$pkg_version="26.01"
 $pkg_license=@("LGPL-2.1", "unRAR restriction")
 $pkg_upstream_url="https://www.7-zip.org/"
 $pkg_description="7-Zip is a file archiver with a high compression ratio"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://www.7-zip.org/a/7z$($pkg_version.Replace('.',''))-x64.exe"
-$pkg_shasum="6fe18d5b3080e39678cabfa6cef12cfb25086377389b803a36a3c43236a8a82c"
+$pkg_shasum="d64a0468f5b5b0b0fc5b2188450bcd655b70809d97b1c4535f2884635094377d"
 $pkg_filename="7z$($pkg_version.Replace('.',''))-x64.exe"
 $pkg_bin_dirs=@("bin")
 


### PR DESCRIPTION
This eliminates active high CVEs recently identified.