### PR TITLE
git bumped to 2.55.0 for linux

### DIFF
--- a/linux/applications/version-management/git/.hab-plan-config.toml
+++ b/linux/applications/version-management/git/.hab-plan-config.toml
@@ -4,6 +4,6 @@ host-script-interpreter = {ignored_files = ["share/**/*.sample"]}
 license-not-found = {level = "off", source-shasum = "0842dc384a23ac33ba3e570c4f3a8ded85963ee4713b1cd21153c3db41813d1e"}
 missing-license = {level = "off", source-shasum = "0842dc384a23ac33ba3e570c4f3a8ded85963ee4713b1cd21153c3db41813d1e"}
 # These packages are needed are runtime
-unused-dependency = {ignored_packages = ["core/{gettext,sed,cacerts,openssh,gcc-libs}"]}
+unused-dependency = {ignored_packages = ["core/{gettext,sed,cacerts,openssh,gcc-libs,rust}"]}
 unused-runpath-entry = {level = "off"}
 missing-script-interpreter-dependency = {level = "off"}

--- a/linux/applications/version-management/git/.hab-plan-config.toml
+++ b/linux/applications/version-management/git/.hab-plan-config.toml
@@ -1,8 +1,8 @@
 [rules]
 # Ignore sample scripts
 host-script-interpreter = {ignored_files = ["share/**/*.sample"]}
-license-not-found = {level = "off", source-shasum = "45e8107643a44e3ce46f5665beb35af3932fb0d70017687905ab5d4e3aafa8eb"}
-missing-license = {level = "off", source-shasum = "45e8107643a44e3ce46f5665beb35af3932fb0d70017687905ab5d4e3aafa8eb"}
+license-not-found = {level = "off", source-shasum = "0842dc384a23ac33ba3e570c4f3a8ded85963ee4713b1cd21153c3db41813d1e"}
+missing-license = {level = "off", source-shasum = "0842dc384a23ac33ba3e570c4f3a8ded85963ee4713b1cd21153c3db41813d1e"}
 # These packages are needed are runtime
 unused-dependency = {ignored_packages = ["core/{gettext,sed,cacerts,openssh,gcc-libs}"]}
 unused-runpath-entry = {level = "off"}

--- a/linux/applications/version-management/git/.hab-plan-config.toml
+++ b/linux/applications/version-management/git/.hab-plan-config.toml
@@ -4,6 +4,6 @@ host-script-interpreter = {ignored_files = ["share/**/*.sample"]}
 license-not-found = {level = "off", source-shasum = "0842dc384a23ac33ba3e570c4f3a8ded85963ee4713b1cd21153c3db41813d1e"}
 missing-license = {level = "off", source-shasum = "0842dc384a23ac33ba3e570c4f3a8ded85963ee4713b1cd21153c3db41813d1e"}
 # These packages are needed are runtime
-unused-dependency = {ignored_packages = ["core/{gettext,sed,cacerts,openssh,gcc-libs,rust}"]}
+unused-dependency = {ignored_packages = ["core/{gettext,sed,cacerts,openssh,gcc-libs}"]}
 unused-runpath-entry = {level = "off"}
 missing-script-interpreter-dependency = {level = "off"}

--- a/linux/applications/version-management/git/plan.sh
+++ b/linux/applications/version-management/git/plan.sh
@@ -1,5 +1,5 @@
 pkg_name="git"
-pkg_version="2.54.0"
+pkg_version="2.55.0"
 pkg_origin="core"
 pkg_description="Git is a free and open source distributed version control
   system designed to handle everything from small to very large projects with
@@ -9,7 +9,7 @@ pkg_license=('GPL-2.0-only' 'LGPL-2.1-only')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://www.kernel.org/pub/software/scm/git/${pkg_name}-${pkg_version}.tar.gz"
 pkg_filename="${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="45e8107643a44e3ce46f5665beb35af3932fb0d70017687905ab5d4e3aafa8eb"
+pkg_shasum="0842dc384a23ac33ba3e570c4f3a8ded85963ee4713b1cd21153c3db41813d1e"
 pkg_deps=(
 	core/bash
 	core/cacerts
@@ -24,6 +24,7 @@ pkg_deps=(
 	core/perl
 	core/sed
 	core/zlib
+	core/rust
 )
 pkg_build_deps=(
 	core/coreutils

--- a/linux/applications/version-management/git/plan.sh
+++ b/linux/applications/version-management/git/plan.sh
@@ -24,7 +24,6 @@ pkg_deps=(
 	core/perl
 	core/sed
 	core/zlib
-	core/rust
 )
 pkg_build_deps=(
 	core/coreutils
@@ -33,6 +32,7 @@ pkg_build_deps=(
 	core/make
 	core/python
 	core/texinfo
+	core/rust
 )
 
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
This pull request updates the Git package to version 2.55.0 and makes related changes to ensure the build and verification processes remain accurate. The most important changes are:

**Version and Integrity Updates:**

* Updated `pkg_version` in `plan.sh` to `2.55.0`, upgrading Git to the latest release.
* Updated `pkg_shasum` in `plan.sh` and `source-shasum` in `.hab-plan-config.toml` to match the new source tarball for version 2.55.0, ensuring integrity verification is correct. [[1]](diffhunk://#diff-df2980b5c5b25498fce60b2b37b6c804842dfb0477c969ae79877f6cb70d832bL12-R12) [[2]](diffhunk://#diff-0296c3bef6cc0c21f6ba1f8cc0ed2d3342d3be1cf29e5cfd968dc5c15482582dL4-R5)

**Build Dependency Changes:**

* Added `core/rust` to `pkg_deps` in `plan.sh` to satisfy new or updated build requirements for Git 2.55.0.