### PR TITLE
Changing the zlib binary names

### DIFF
--- a/windows/development/libraries/protobuf/plan.ps1
+++ b/windows/development/libraries/protobuf/plan.ps1
@@ -25,7 +25,7 @@ function Invoke-Build {
 	git clone -b lts_2023_08_02 https://github.com/abseil/abseil-cpp.git $HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version\third_party/abseil-cpp
     Set-Location "$pkg_name-$pkg_version\cmake"
 
-    $zlib_libdir = "$(Get-HabPackagePath zlib)\lib\zlibwapi.lib"
+    $zlib_libdir = "$(Get-HabPackagePath zlib)\lib\z.lib"
     $zlib_includedir = "$(Get-HabPackagePath zlib)\include"
 
     mkdir build

--- a/windows/development/libraries/zlib/plan.ps1
+++ b/windows/development/libraries/zlib/plan.ps1
@@ -19,16 +19,15 @@ function Invoke-Build {
 	# zlib 1.3.2 requires cmake for building.
 	mkdir cmake-build
     Set-Location cmake-build
-    cmake -G "Visual Studio 17 2022" -A "x64" -T "v143" -DCMAKE_SYSTEM_VERSION="10.0" -DCMAKE_INSTALL_PREFIX="${prefix_path}\zlib" -DENABLE_CURVE="false" ..
-
+    cmake -G "Visual Studio 17 2022" -A "x64" -T "v143" -DCMAKE_SYSTEM_VERSION="10.0" -DCMAKE_INSTALL_PREFIX="${prefix_path}\zlib" ..
     msbuild /p:Configuration=Release /p:Platform=x64 "zlib.sln"
     if($LASTEXITCODE -ne 0) { Write-Error "msbuild failed!" }
 }
 
 function Invoke-Install {
     
-	Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version\cmake-build\Release\z.dll" "$pkg_prefix\bin\zlibwapi.dll" -Force
-    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version\cmake-build\Release\z.lib" "$pkg_prefix\lib\zlibwapi.lib" -Force
+	Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version\cmake-build\Release\z.dll" "$pkg_prefix\bin\z.dll" -Force
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version\cmake-build\Release\z.lib" "$pkg_prefix\lib\z.lib" -Force
     Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version\zlib.h" "$pkg_prefix\include\" -Force
     Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version\zconf.h" "$pkg_prefix\include\" -Force
 


### PR DESCRIPTION
This pull request updates the Windows build process for `zlib` and its usage in dependent projects to standardize the naming of the output library and DLL files. The changes ensure that the built artifacts use the upstream default names (`z.lib` and `z.dll`) rather than custom names (`zlibwapi.lib` and `zlibwapi.dll`), improving compatibility and simplifying maintenance.

**Build artifact naming standardization:**

* Updated the `zlib` build and install scripts in `windows/development/libraries/zlib/plan.ps1` to output and install `z.lib` and `z.dll` instead of `zlibwapi.lib` and `zlibwapi.dll`.
* Modified the `protobuf` build script in `windows/development/libraries/protobuf/plan.ps1` to reference `z.lib` instead of `zlibwapi.lib` when linking against `zlib`.

**Build configuration cleanup:**

* Removed the unused `-DENABLE_CURVE="false"` option from the CMake invocation in the `zlib` build script, as it is not recognized by the current version of `zlib`.